### PR TITLE
no internal static path

### DIFF
--- a/centrifuge/node.py
+++ b/centrifuge/node.py
@@ -144,10 +144,6 @@ def create_centrifuge_application():
             os.path.dirname(__file__),
             os.path.join("web/frontend", "templates")
         ),
-        static_path=os.path.join(
-            os.path.dirname(__file__),
-            os.path.join("web/frontend", "static")
-        ),
         xsrf_cookies=False,
         autoescape="xhtml_escape",
         debug=options.debug,


### PR DESCRIPTION
Из-за того, что в настройках Tornado указан стандартный static_path, в дальнейшем происходит конфликт при попытке запросить файл из корневой директории web-клиента, переданный в centrifuge через аргумент --web (Tornado пытается найти файл в директории centrifuge/web/frontend, web-клиент уже вынесен в отдельный проект).
